### PR TITLE
remove go mod proxy goproxy.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ WORKDIR /go/src/github.com/nooncall/shazam
 COPY go.mod .
 COPY go.sum .
 
-ENV GOPROXY https://goproxy.io
 RUN GO111MODULE=on go mod download
 
 # Build real binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN GO111MODULE=on go mod download
 
 # Build real binaries
 COPY . .
-RUN make shazam-proxy
+RUN CGO_ENABLED=0 make shazam-proxy
 
 # Executable image
 FROM alpine


### PR DESCRIPTION
remove go mod proxy goproxy.io, which broken the build process.
```
go: finding gopkg.in/yaml.v2 v2.2.1
go: finding honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099
verifying github.com/google/go-cmp@v0.2.0: github.com/google/go-cmp@v0.2.0: reading https://goproxy.io/sumdb/sum.golang.org/lookup/github.com/google/go-cmp@v0.2.0: 410 Gone
Removing intermediate container c10e9c45c860
The command '/bin/sh -c GO111MODULE=on go mod download' returned a non-zero code: 1
```