### PR TITLE
fix: race condition in txConns

### DIFF
--- a/proxy/server/executor_handle.go
+++ b/proxy/server/executor_handle.go
@@ -291,6 +291,9 @@ func (se *SessionExecutor) handleSetVariable(v *ast.VariableAssignment) error {
 }
 
 func (se *SessionExecutor) handleSetAutoCommit(autocommit bool) error {
+	se.txLock.Lock()
+	defer se.txLock.Unlock()
+
 	if autocommit {
 		se.status |= mysql.ServerStatusAutocommit
 		if se.status&mysql.ServerStatusInTrans > 0 {


### PR DESCRIPTION
use txConns in Executor without locking can cause race condition, which leads to gaea-proxy panic (#50)

fix this problem by adding lock to txConns.